### PR TITLE
Tf 0.12 readme details + Makefile w/ git-release

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/binbashar/terraform-aws-cost-billing-alarm
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 !*.dockeringnore
 !*.hosts
 !/.gitignore
+!/.chglog
 !/.gitallowed
 !*.gitkeep
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
+project adheres to [Semantic Versioning](http://semver.org/).
+
+---
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
-project adheres to [Semantic Versioning](http://semver.org/).
-
----
-

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,12 @@ doc: ## doc: A utility to generate documentation from Terraform modules in vario
 
 lint: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
 	docker run --rm -v ${TF_PWD_DIR}:/data -t wata727/tflint --deep
+
+changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
+	# pre-req -> https://github.com/pnikosis/semtag
+	docker run -it --rm -v "${TF_PWD_DIR}:/data" binbash/git-chglog --init
+	docker run -it --rm -v "${TF_PWD_DIR}:/data" binbash/git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+
+release: ##
+	segtag get
+	semtag final -s minor

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help
 SHELL := /bin/bash
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
 
 TF_PWD_DIR := $(shell pwd)
 TF_VER := 0.11.14
@@ -13,6 +16,20 @@ docker run --rm \
 --entrypoint=${TF_DOCKER_ENTRYPOINT} \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
 endef
+
+# pre-req -> https://github.com/pnikosis/semtag
+define GIT_SEMTAG_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:/data:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+--entrypoint=/opt/semtag/semtag/semtag \
+-it binbash/git-release
+endef
+
+GIT_SEMTAG_VER_PATCH := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s patch -o)
+GIT_SEMTAG_VER_MINOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s minor -o)
+GIT_SEMTAG_VER_MINOR := $(shell ${GIT_SEMTAG_CMD_PREFIX} final -s major -o)
 
 help:
 	@echo 'Available Commands:'
@@ -32,11 +49,44 @@ doc: ## doc: A utility to generate documentation from Terraform modules in vario
 lint: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
 	docker run --rm -v ${TF_PWD_DIR}:/data -t wata727/tflint --deep
 
-changelog: ## git changelog (https://github.com/git-chglog/git-chglog)
+release-patch: ## releasing patch (eg: 0.0.1 -> 0.0.2) based on semantic tagging script for Git
 	# pre-req -> https://github.com/pnikosis/semtag
-	docker run -it --rm -v "${TF_PWD_DIR}:/data" binbash/git-chglog --init
-	docker run -it --rm -v "${TF_PWD_DIR}:/data" binbash/git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s patch
 
-release: ##
-	segtag get
-	semtag final -s minor
+release-minor: ## releasing minor (eg: 0.0.2 -> 0.1.0) based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s minor
+
+release-major: ## releasing major (eg: 0.1.0 -> 1.0.0) based on semantic tagging script for Git
+	# pre-req -> https://github.com/pnikosis/semtag
+	${GIT_SEMTAG_CMD_PREFIX} get
+	${GIT_SEMTAG_CMD_PREFIX} final -s major
+
+changelog-init: ## git-chglog (https://github.com/git-chglog/git-chglog) config initialization -> ./.chglog
+	@if [ ! -d ./.chglog ]; then\
+		docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release --init;\
+		sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog;\
+	else\
+		  echo "==============================";\
+    	echo "git-chglog already initialized";\
+    	echo "==============================";\
+    	echo "$$(ls ./.chglog)";\
+    	echo "==============================";\
+	fi
+
+changelog-patch: ## git-chglog generation for path release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_PATCH}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+
+changelog-minor: ## git-chglog generation for minor release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_MINOR}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md
+
+changelog-major: ## git-chglog generation for major release
+	docker run --rm -v ${TF_PWD_DIR}:/data -it binbash/git-release -o CHANGELOG.md --next-tag ${GIT_SEMTAG_VER_MAJOR}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.chglog
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Adds a billing alert with optional sns topic creation (or use a pre-existing one
 If `aws_sns_topic_enabled = true` then you'll still need to subscribe to the created SNS topic manually (please check **Important Consderations** section for detailed info).
 
 ## Releases
-- **Versions:** `0.x.y` (Terraform 0.11.x compatible)
+- **Versions:** `<= 0.x.y` (Terraform 0.11.x compatible)
     - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1
 
-- **Versions:** `1.x.y` (Terraform 0.12.x compatible -> **WIP**)
+- **Versions:** `>= 1.x.y` (Terraform 0.12.x compatible -> **WIP**)
     - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/1.0.0
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Adds a billing alert with optional sns topic creation (or use a pre-existing one
 
 If `aws_sns_topic_enabled = true` then you'll still need to subscribe to the created SNS topic manually (please check **Important Consderations** section for detailed info).
 
+## Releases
+- **Versions:** `0.x.y` (Terraform 0.11.x compatible)
+    - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1
+
+- **Versions:** `1.x.y` (Terraform 0.12.x compatible -> **WIP**)
+    - eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/1.0.0
+
 ## Inputs
 
 There are several required variables for this module.


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> terraform-aws-cost-billing-alarm repo:

<div align="middle">
  <img src="http://automationtoolsbootcamp.com/images/terraform.png" alt="terraform" width="150"/>
  <img src="https://pbs.twimg.com/profile_images/907881675304181760/_ftIQb3v_400x400.jpg" alt="aws" width="150"/>
</div>

###  :notebook: Summary 
1. Updating README.md with tf 0.12 release info
```
Releases
Versions: <= 0.x.y (Terraform 0.11.x compatible)

eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/0.0.1
Versions: >= 1.x.y (Terraform 0.12.x compatible -> WIP)

eg: https://registry.terraform.io/modules/binbashar/cost-budget/aws/1.0.0
```  
2. Adding `Makefile` to follow the new standard dockerized git-release cross-project modules approach release tagging.
Since the need of generating consistent cross-project versioning tagging we've decided to automate this task in our Makefiles.
Ref: https://github.com/binbashar/public-docker-images/pull/10

### :man_technologist:  New Commits 
- adding tf 0.12 related readme.md updates
- updating tf 0.12 related readme.md with exact release ver
- Adding git-release support in makefile with git-chglog and semtag

### :triangular_flag_on_post:  Post Tasks
- Update release tag `0.0.2` after PR merged to master in order to reflect the updates at the Terraform Registry -> https://registry.terraform.io/modules/binbashar/cost-billing-alarm/aws/0.0.1.  

### :1st_place_medal:  TODO
- Add `terratest` to this module.
- Add new version `1.0.0` with tf-0.12 support.