### PR TITLE
Examples makefile terratest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Hidden files #
 ################
 .*
+#
+# Except
+#
 !*.env.example
 !*.dockeringnore
 !*.hosts
@@ -8,6 +11,11 @@
 !/.chglog
 !/.gitallowed
 !*.gitkeep
+
+# SSH keys #
+############
+id_rsa
+id_dsa
 
 # OS generated files #
 ######################
@@ -33,6 +41,9 @@ Thumbs.db
 *.zip
 *.tar.gz
 
+#
+# Except
+#
 !lambda_function.*.zip
 !lambda_function.lambda_handler.zip
 !lambda_function.*.zip
@@ -65,9 +76,12 @@ Thumbs.db
 
 # TF Project files #
 ####################
+#
 # Compiled files
+#
 *.tfstate
 *.tfstate.backup
-
+#
 # Module directory
+#
 .terraform

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ SHELL := /bin/bash
 LOCAL_OS_USER := $(shell whoami)
 LOCAL_OS_SSH_DIR := ~/.ssh
 LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
 
 TF_PWD_DIR := $(shell pwd)
 TF_VER := 0.11.14
@@ -10,6 +11,12 @@ TF_PWD_CONT_DIR := "/go/src/project/"
 TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
 TF_DOCKER_IMAGE := binbash/terraform-resources
 
+TERRATEST_DOCKER_ENTRYPOINT := dep
+TERRATEST_DOCKER_WORKDIR := /go/src/project/tests
+
+#
+# TERRAFORM
+#
 define TF_CMD_PREFIX
 docker run --rm \
 -v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
@@ -17,6 +24,31 @@ docker run --rm \
 -it ${TF_DOCKER_IMAGE}:${TF_VER}
 endef
 
+#
+# TERRATEST
+#
+define TERRATEST_GO_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+-w ${TERRATEST_DOCKER_WORKDIR} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+define TERRATEST_DEP_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+--entrypoint=${TERRATEST_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+#
+# GIT-RELEASE
+#
 # pre-req -> https://github.com/pnikosis/semtag
 define GIT_SEMTAG_CMD_PREFIX
 docker run --rm \
@@ -35,33 +67,58 @@ help:
 	@echo 'Available Commands:'
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
 
-version: ## version: show terraform version
+
+#==============================================================#
+# TERRAFORM 												   #
+#==============================================================#
+version: ## Show terraform version
 	docker run --rm \
 	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
 	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
 
-format: ## format: The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
 	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
 
-doc: ## doc: A utility to generate documentation from Terraform modules in various output formats.
+doc: ## A utility to generate documentation from Terraform modules in various output formats.
 	docker run --rm -v ${TF_PWD_DIR}:/data -t binbash/terraform-docs markdown table /data
 
-lint: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
+lint: ## TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
 	docker run --rm -v ${TF_PWD_DIR}:/data -t wata727/tflint --deep
 
+
+#==============================================================#
+# TERRATEST 												   #
+#==============================================================#
+terratest-dep-init: ## dep is a dependency management tool for Go. (https://github.com/golang/dep)
+	${TERRATEST_DEP_CMD_PREFIX} init
+	${TERRATEST_DEP_CMD_PREFIX} ensure
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} .
+	cp -r ./vendor ./tests/ && rm -rf ./vendor
+	cp -r ./Gopkg* ./tests/ && rm -rf ./Gopkg*
+
+terratest-go-test: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
+	${TERRATEST_GO_CMD_PREFIX} test
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} .
+
+#==============================================================#
+# GIT RELEASE 												   #
+#==============================================================#
 release-patch: ## releasing patch (eg: 0.0.1 -> 0.0.2) based on semantic tagging script for Git
 	# pre-req -> https://github.com/pnikosis/semtag
 	${GIT_SEMTAG_CMD_PREFIX} get
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.git
 	${GIT_SEMTAG_CMD_PREFIX} final -s patch
 
 release-minor: ## releasing minor (eg: 0.0.2 -> 0.1.0) based on semantic tagging script for Git
 	# pre-req -> https://github.com/pnikosis/semtag
 	${GIT_SEMTAG_CMD_PREFIX} get
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.git
 	${GIT_SEMTAG_CMD_PREFIX} final -s minor
 
 release-major: ## releasing major (eg: 0.1.0 -> 1.0.0) based on semantic tagging script for Git
 	# pre-req -> https://github.com/pnikosis/semtag
 	${GIT_SEMTAG_CMD_PREFIX} get
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.git
 	${GIT_SEMTAG_CMD_PREFIX} final -s major
 
 changelog-init: ## git-chglog (https://github.com/git-chglog/git-chglog) config initialization -> ./.chglog

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-    <img src="https://github.com/binbashar/terraform-aws-cost-billing-alarm/blob/master/figures/binbash.png" alt="drawing" width="350"/>
+    <img src="https://raw.githubusercontent.com/binbashar/terraform-aws-cost-billing-alarm/master/figures/binbash.png" alt="drawing" width="350"/>
 </div>
 <div align="right">
-  <img src="https://github.com/binbashar/terraform-aws-cost-billing-alarm/blob/master/figures/binbash-leverage-terraform.png" alt="leverage" width="230"/>
+  <img src="https://raw.githubusercontent.com/binbashar/terraform-aws-cost-billing-alarm/master/figures/binbash-leverage-terraform.png" alt="leverage" width="230"/>
 </div>
 
 # AWS Billing Cloudwatch Alarm terraform module: terraform-aws-cost-mgmt-billing-alarm

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-    <img src="https://binbashar.github.io/terraform-aws-cost-billing-alarm/figures/binbash.png" alt="drawing" width="350"/>
+    <img src="https://github.com/binbashar/terraform-aws-cost-billing-alarm/blob/master/figures/binbash.png" alt="drawing" width="350"/>
 </div>
 <div align="right">
-  <img src="https://binbashar.github.io/terraform-aws-cost-billing-alarm/figures/binbash-leverage-terraform.png" alt="leverage" width="230"/>
+  <img src="https://github.com/binbashar/terraform-aws-cost-billing-alarm/blob/master/figures/binbash-leverage-terraform.png" alt="leverage" width="230"/>
 </div>
 
 # AWS Billing Cloudwatch Alarm terraform module: terraform-aws-cost-mgmt-billing-alarm

--- a/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/Makefile
+++ b/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/Makefile
@@ -1,0 +1,69 @@
+.PHONY: help
+SHELL := /bin/bash
+
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
+TF_PWD_DIR := $(shell pwd)
+TF_PWD_CONT_DIR := "/go/src/project/"
+TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)
+TF_VER := 0.11.14
+TF_DOCKER_BACKEND_CONF_VARS_FILE := /config/backend.config
+TF_DOCKER_MAIN_CONF_VARS_FILE := /config/main.config
+TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
+TF_DOCKER_IMAGE := binbash/terraform-resources
+
+define TF_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${TF_PWD_CONFIG_DIR}:/config \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER: ${LOCAL_OS_USER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.terraform
+
+version: ## Show terraform version
+	docker run --rm \
+	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
+
+init: init-cmd tf-dir-chmod
+init-cmd: ## Initialize terraform backend, plugins, and modules"
+	${TF_CMD_PREFIX} init -backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan: ## Preview terraform changes"
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan-detailed: ## Preview terraform changes with a more detailed output"
+	${TF_CMD_PREFIX} plan -detailed-exitcode -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+diff: ## Terraform plan with landscape
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} | docker run -i --rm binbash/terraform-landscape
+
+apply: apply-cmd tf-dir-chmod
+apply-cmd: ## Make terraform apply any changes"
+	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+output: ## Terraform output command is used to extract the value of an output variable from the state file.
+	terraform output
+
+destroy: ## Destroy all resources managed by terraform"
+	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
+
+force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}

--- a/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/README.md
+++ b/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/README.md
@@ -45,8 +45,7 @@ output "sns_topic" {
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-### For Private Security Groups
-#### sec-group-private-tcp
+## cloudwatch-billing-alert-to-new-sns-consolidated-acct
 ```terraform
 module "billing_cloudwatch_alert" {
   source = "../../cost-mgmt-billing-alarm-bb"

--- a/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/README.md
+++ b/examples/cloudwatch-billing-alert-to-new-sns-consolidated-acct/README.md
@@ -1,0 +1,62 @@
+# AWS Billing Alert
+## cloudwatch-billing-alert-to-new-sns-consolidated-acct
+
+Configuration in this directory creates set of AWS resources which may be sufficient for a fully working stage or prod
+billing alert with optional sns topic creation (or use a pre-existing one) to alert when
+a U$S (currency actually configurable) billing threshold is reached.
+
+Please check the **input parameters** for a better understanding of it.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Or if using the `Makefile` in this repo you need to execute:
+
+```bash
+$ make init
+$ make plan
+$ make apply
+```
+
+Note that this example may create resources which can cost money (AWS EC2, for example). Run `terraform destroy` or `make destroy`
+when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sns\_topic\_arn | SNS Topic ARN to be subscribed to in order to delivery the clodwatch billing alarms
+
+The module outputs one block, sns_topic. Access it like this:
+
+```
+output "sns_topic" {
+  value = "${module.billing_alert.sns_topic}"
+}
+```
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+### For Private Security Groups
+#### sec-group-private-tcp
+```terraform
+module "billing_cloudwatch_alert" {
+  source = "../../cost-mgmt-billing-alarm-bb"
+
+  aws_env                   = "${var.aws_profile}"
+  monthly_billing_threshold = 500
+  currency                  = "USD"
+}
+
+output "sns_topic" {
+  value = "${module.billing_cloudwatch_alert.sns_topic}"
+}
+```

--- a/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/Makefile
+++ b/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/Makefile
@@ -1,0 +1,69 @@
+.PHONY: help
+SHELL := /bin/bash
+
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
+TF_PWD_DIR := $(shell pwd)
+TF_PWD_CONT_DIR := "/go/src/project/"
+TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)
+TF_VER := 0.11.14
+TF_DOCKER_BACKEND_CONF_VARS_FILE := /config/backend.config
+TF_DOCKER_MAIN_CONF_VARS_FILE := /config/main.config
+TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
+TF_DOCKER_IMAGE := binbash/terraform-resources
+
+define TF_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${TF_PWD_CONFIG_DIR}:/config \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER: ${LOCAL_OS_USER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.terraform
+
+version: ## Show terraform version
+	docker run --rm \
+	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
+
+init: init-cmd tf-dir-chmod
+init-cmd: ## Initialize terraform backend, plugins, and modules"
+	${TF_CMD_PREFIX} init -backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan: ## Preview terraform changes"
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan-detailed: ## Preview terraform changes with a more detailed output"
+	${TF_CMD_PREFIX} plan -detailed-exitcode -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+diff: ## Terraform plan with landscape
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} | docker run -i --rm binbash/terraform-landscape
+
+apply: apply-cmd tf-dir-chmod
+apply-cmd: ## Make terraform apply any changes"
+	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+output: ## Terraform output command is used to extract the value of an output variable from the state file.
+	terraform output
+
+destroy: ## Destroy all resources managed by terraform"
+	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
+
+force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}

--- a/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/README.md
+++ b/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/README.md
@@ -1,0 +1,63 @@
+# AWS Billing Alert
+## cloudwatch-billing-alert-to-new-sns-with-acct-id
+
+Configuration in this directory creates set of AWS resources which may be sufficient for a fully working stage or prod
+billing alert with optional sns topic creation (or use a pre-existing one) to alert when
+a U$S (currency actually configurable) billing threshold is reached.
+
+Please check the **input parameters** for a better understanding of it.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Or if using the `Makefile` in this repo you need to execute:
+
+```bash
+$ make init
+$ make plan
+$ make apply
+```
+
+Note that this example may create resources which can cost money (AWS EC2, for example). Run `terraform destroy` or `make destroy`
+when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sns\_topic\_arn | SNS Topic ARN to be subscribed to in order to delivery the clodwatch billing alarms
+
+The module outputs one block, sns_topic. Access it like this:
+
+```
+output "sns_topic" {
+  value = "${module.billing_alert.sns_topic}"
+}
+```
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+### For Private Security Groups
+#### sec-group-private-tcp
+```terraform
+module "billing_cloudwatch_alert" {
+  source = "../../cost-mgmt-billing-alarm-bb"
+
+  aws_env                   = "${var.aws_profile}"
+  aws_account_id            = 111111111111
+  monthly_billing_threshold = 500
+  currency                  = "USD"
+}
+
+output "sns_topic" {
+  value = "${module.billing_cloudwatch_alert.sns_topic}"
+}
+```

--- a/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/README.md
+++ b/examples/cloudwatch-billing-alert-to-new-sns-with-acct-id/README.md
@@ -45,8 +45,7 @@ output "sns_topic" {
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-### For Private Security Groups
-#### sec-group-private-tcp
+## cloudwatch-billing-alert-to-new-sns-with-acct-id
 ```terraform
 module "billing_cloudwatch_alert" {
   source = "../../cost-mgmt-billing-alarm-bb"

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/Makefile
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/Makefile
@@ -1,0 +1,69 @@
+.PHONY: help
+SHELL := /bin/bash
+
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
+TF_PWD_DIR := $(shell pwd)
+TF_PWD_CONT_DIR := "/go/src/project/"
+TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)
+TF_VER := 0.11.14
+TF_DOCKER_BACKEND_CONF_VARS_FILE := /config/backend.config
+TF_DOCKER_MAIN_CONF_VARS_FILE := /config/main.config
+TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
+TF_DOCKER_IMAGE := binbash/terraform-resources
+
+define TF_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${TF_PWD_CONFIG_DIR}:/config \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER: ${LOCAL_OS_USER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.terraform
+
+version: ## Show terraform version
+	docker run --rm \
+	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
+
+init: init-cmd tf-dir-chmod
+init-cmd: ## Initialize terraform backend, plugins, and modules"
+	${TF_CMD_PREFIX} init -backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan: ## Preview terraform changes"
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan-detailed: ## Preview terraform changes with a more detailed output"
+	${TF_CMD_PREFIX} plan -detailed-exitcode -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+diff: ## Terraform plan with landscape
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} | docker run -i --rm binbash/terraform-landscape
+
+apply: apply-cmd tf-dir-chmod
+apply-cmd: ## Make terraform apply any changes"
+	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+output: ## Terraform output command is used to extract the value of an output variable from the state file.
+	terraform output
+
+destroy: ## Destroy all resources managed by terraform"
+	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
+
+force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/README.md
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/README.md
@@ -45,8 +45,7 @@ output "sns_topic" {
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-### For Private Security Groups
-#### sec-group-private-tcp
+## cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct
 ```terraform
 module "billing_cloudwatch_alert" {
   source = "../../cost-mgmt-billing-alarm-bb"

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/README.md
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct/README.md
@@ -1,0 +1,63 @@
+# AWS Billing Alert
+## cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct
+
+Configuration in this directory creates set of AWS resources which may be sufficient for a fully working stage or prod
+billing alert with optional sns topic creation (or use a pre-existing one) to alert when
+a U$S (currency actually configurable) billing threshold is reached.
+
+Please check the **input parameters** for a better understanding of it.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Or if using the `Makefile` in this repo you need to execute:
+
+```bash
+$ make init
+$ make plan
+$ make apply
+```
+
+Note that this example may create resources which can cost money (AWS EC2, for example). Run `terraform destroy` or `make destroy`
+when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sns\_topic\_arn | SNS Topic ARN to be subscribed to in order to delivery the clodwatch billing alarms
+
+The module outputs one block, sns_topic. Access it like this:
+
+```
+output "sns_topic" {
+  value = "${module.billing_alert.sns_topic}"
+}
+```
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+### For Private Security Groups
+#### sec-group-private-tcp
+```terraform
+module "billing_cloudwatch_alert" {
+  source = "../../cost-mgmt-billing-alarm-bb"
+
+  aws_env                   = "${var.aws_profile}"
+  monthly_billing_threshold = 500
+  currency                  = "USD"
+  aws_sns_topic_arn         = "arn:aws:lambda:us-east-1:111111111111:function:bb-root-org-notify_slack"
+}
+
+output "sns_topic" {
+  value = "${module.billing_cloudwatch_alert.sns_topic}"
+}
+```

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/Makefile
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/Makefile
@@ -1,0 +1,69 @@
+.PHONY: help
+SHELL := /bin/bash
+
+LOCAL_OS_USER := $(shell whoami)
+LOCAL_OS_SSH_DIR := ~/.ssh
+LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
+LOCAL_OS_AWS_CONF_DIR := ~/.aws
+
+TF_PWD_DIR := $(shell pwd)
+TF_PWD_CONT_DIR := "/go/src/project/"
+TF_PWD_CONFIG_DIR := $(shell cd .. && cd config && pwd)
+TF_VER := 0.11.14
+TF_DOCKER_BACKEND_CONF_VARS_FILE := /config/backend.config
+TF_DOCKER_MAIN_CONF_VARS_FILE := /config/main.config
+TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
+TF_DOCKER_IMAGE := binbash/terraform-resources
+
+define TF_CMD_PREFIX
+docker run --rm \
+-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
+-v ${TF_PWD_CONFIG_DIR}:/config \
+-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
+-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
+-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
+--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+-it ${TF_DOCKER_IMAGE}:${TF_VER}
+endef
+
+help:
+	@echo 'Available Commands:'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " - \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+tf-dir-chmod: ## run chown in ./.terraform to gran that the docker mounted dir has the right permissions
+	@echo LOCAL_OS_USER: ${LOCAL_OS_USER}
+	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} ./.terraform
+
+version: ## Show terraform version
+	docker run --rm \
+	--entrypoint=${TF_DOCKER_ENTRYPOINT} \
+	-t ${TF_DOCKER_IMAGE}:${TF_VER} version
+
+init: init-cmd tf-dir-chmod
+init-cmd: ## Initialize terraform backend, plugins, and modules"
+	${TF_CMD_PREFIX} init -backend-config=${TF_DOCKER_BACKEND_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan: ## Preview terraform changes"
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+plan-detailed: ## Preview terraform changes with a more detailed output"
+	${TF_CMD_PREFIX} plan -detailed-exitcode -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+diff: ## Terraform plan with landscape
+	${TF_CMD_PREFIX} plan -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} | docker run -i --rm binbash/terraform-landscape
+
+apply: apply-cmd tf-dir-chmod
+apply-cmd: ## Make terraform apply any changes"
+	${TF_CMD_PREFIX} apply -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+output: ## Terraform output command is used to extract the value of an output variable from the state file.
+	terraform output
+
+destroy: ## Destroy all resources managed by terraform"
+	${TF_CMD_PREFIX} destroy -var-file=${TF_DOCKER_BACKEND_CONF_VARS_FILE} -var-file=${TF_DOCKER_MAIN_CONF_VARS_FILE} ${TF_PWD_CONT_DIR}
+
+format: ## The terraform fmt is used to rewrite tf conf files to a canonical format and style.
+	${TF_CMD_PREFIX} fmt ${TF_PWD_CONT_DIR}
+
+force-unlock: ## Manually unlock the terraform state, eg: make ARGS="a94b0919-de5b-9b8f-4bdf-f2d7a3d47112" force-unlock
+	${TF_CMD_PREFIX} force-unlock ${ARGS} ${TF_PWD_CONT_DIR}

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/README.md
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/README.md
@@ -45,8 +45,7 @@ output "sns_topic" {
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
-### For Private Security Groups
-#### sec-group-private-tcp
+## cloudwatch-billing-alert-to-pre-existing-sns-consolidated-acct
 ```terraform
 module "billing_cloudwatch_alert" {
   source = "../../cost-mgmt-billing-alarm-bb"

--- a/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/README.md
+++ b/examples/cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id/README.md
@@ -1,0 +1,60 @@
+# AWS Billing Alert
+## cloudwatch-billing-alert-to-pre-existing-sns-with-acct-id
+
+Configuration in this directory creates set of AWS resources which may be sufficient for a fully working stage or prod
+billing alert with optional sns topic creation (or use a pre-existing one) to alert when
+a U$S (currency actually configurable) billing threshold is reached.
+
+Please check the **input parameters** for a better understanding of it.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Or if using the `Makefile` in this repo you need to execute:
+
+```bash
+$ make init
+$ make plan
+$ make apply
+```
+
+Note that this example may create resources which can cost money (AWS EC2, for example). Run `terraform destroy` or `make destroy`
+when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| sns\_topic\_arn | SNS Topic ARN to be subscribed to in order to delivery the clodwatch billing alarms
+
+The module outputs one block, sns_topic. Access it like this:
+
+```
+output "sns_topic" {
+  value = "${module.billing_alert.sns_topic}"
+}
+```
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+### For Private Security Groups
+#### sec-group-private-tcp
+```terraform
+module "billing_cloudwatch_alert" {
+  source = "../../cost-mgmt-billing-alarm-bb"
+
+  aws_env                   = "${var.aws_profile}"
+  aws_account_id            = 111111111111
+  monthly_billing_threshold = 500
+  currency                  = "USD"
+  aws_sns_topic_arn         = "arn:aws:lambda:us-east-1:111111111111:function:bb-root-org-notify_slack"
+}
+```


### PR DESCRIPTION
## Updating <img src="https://avatars1.githubusercontent.com/u/31255874?s=280&v=4" alt="binbash" width="40"/> terraform-aws-cost-billing-alarm repo:

<div align="middle">
  <img src="http://automationtoolsbootcamp.com/images/terraform.png" alt="terraform" width="150"/>
  <img src="https://pbs.twimg.com/profile_images/907881675304181760/_ftIQb3v_400x400.jpg" alt="aws" width="150"/>
</div>

###  :notebook: Summary 
1. Adding README.md in example folders to avoid the following warning message at https://registry.terraform.io.
![image](https://user-images.githubusercontent.com/18539704/60928350-6f1b8200-a283-11e9-9b91-2ce08d82e56a.png)
  
2. Adding `Makefile` to follow the new standard dockerized terratest cross-project modules approach for terraform testing.
```makefile
.PHONY: help
SHELL := /bin/bash
LOCAL_OS_USER := $(shell whoami)
LOCAL_OS_SSH_DIR := ~/.ssh
LOCAL_OS_GIT_CONF_DIR := ~/.gitconfig
LOCAL_OS_AWS_CONF_DIR := ~/.aws

TF_PWD_DIR := $(shell pwd)
TF_VER := 0.11.14
TF_PWD_CONT_DIR := "/go/src/project/"
TF_DOCKER_ENTRYPOINT := /usr/local/go/bin/terraform
TF_DOCKER_IMAGE := binbash/terraform-resources

TERRATEST_DOCKER_ENTRYPOINT := dep
TERRATEST_DOCKER_WORKDIR := /go/src/project/tests

#
# TERRAFORM
#
define TF_CMD_PREFIX
docker run --rm \
-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
--entrypoint=${TF_DOCKER_ENTRYPOINT} \
-it ${TF_DOCKER_IMAGE}:${TF_VER}
endef

#
# TERRATEST
#
define TERRATEST_GO_CMD_PREFIX
docker run --rm \
-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
-v ${LOCAL_OS_AWS_CONF_DIR}:/root/.aws \
-w ${TERRATEST_DOCKER_WORKDIR} \
-it ${TF_DOCKER_IMAGE}:${TF_VER}
endef

define TERRATEST_DEP_CMD_PREFIX
docker run --rm \
-v ${TF_PWD_DIR}:${TF_PWD_CONT_DIR}:rw \
-v ${LOCAL_OS_SSH_DIR}:/root/.ssh \
-v ${LOCAL_OS_GIT_CONF_DIR}:/etc/gitconfig \
--entrypoint=${TERRATEST_DOCKER_ENTRYPOINT} \
-it ${TF_DOCKER_IMAGE}:${TF_VER}
endef

#==============================================================#
# TERRATEST 												   #
#==============================================================#
terratest-dep-init: ## dep is a dependency management tool for Go. (https://github.com/golang/dep)
	${TERRATEST_DEP_CMD_PREFIX} init
	${TERRATEST_DEP_CMD_PREFIX} ensure
	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} .
	cp -r ./vendor ./tests/ && rm -rf ./vendor
	cp -r ./Gopkg* ./tests/ && rm -rf ./Gopkg*

terratest-go-test: ## lint: TFLint is a Terraform linter for detecting errors that can not be detected by terraform plan.
	${TERRATEST_GO_CMD_PREFIX} test
	sudo chown -R ${LOCAL_OS_USER}:${LOCAL_OS_USER} .
```

### :man_technologist:  New Commits 
- 9a9b570 - .gitignore updated to its std cross-project format
- a2023f1 - Updating Makefile to support terratests cmds
- aab9bca - Adding examples README.mds to avoid - Submodules without a README or README.md are considered to be internal-only by the Terraform Module Registry.
- 78811b0 - fixing example README.md title


### :triangular_flag_on_post:  Post Tasks
- Release new version with `make release-patch` & `changelog-patch`

### :1st_place_medal:  TODO
- Add `terratest` to this module.
- Add new version `1.0.0` with tf-0.12 support.