### PR TITLE
Fix | ISSUE-18: Add new variable to set datapoints_to_alarm attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ No modules.
 | <a name="input_currency"></a> [currency](#input\_currency) | Short notation for currency type (e.g. USD, CAD, EUR) | `string` | `"USD"` | no |
 | <a name="input_monthly_billing_threshold"></a> [monthly\_billing\_threshold](#input\_monthly\_billing\_threshold) | The threshold for which estimated monthly charges will trigger the metric alarm. | `string` | n/a | yes |
 | <a name="input_sns_topic_arns"></a> [sns\_topic\_arns](#input\_sns\_topic\_arns) | List of SNS topic ARNs to be used. If `create_sns_topic` is `true`, it merges the created SNS Topic by this module with this list of ARNs | `list(string)` | `[]` | no |
+| <a name="input_datapoints_to_alarm"></a> [datapoints\_to\_alarm](#input\_datapoint\_to\_alarm) | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "account_billing_alarm" {
   statistic           = lookup(local.alarm, "statistic", "Maximum")
   threshold           = lookup(local.alarm, "threshold")
   alarm_actions       = lookup(local.alarm, "alarm_actions")
+  datapoints_to_alarm = var.datapoints_to_alarm
 
   dimensions = {
     Currency      = lookup(lookup(local.alarm, "dimensions"), "currency")

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "aws_account_id" {
   default     = null
 }
 
+variable "datapoints_to_alarm" {
+  description = "The number of datapoints that must be breaching to trigger the alarm."
+  type        = number
+  default     = null
+}
+
 #=============================#
 # SNS                         #
 #=============================#


### PR DESCRIPTION
## what
* Add a new variable to explicitly set the `datapoints_to_alarm` attribute.

## why
* To ensure that it will have the desired value, even after the aws provider upgrade.

## references
* `closes issue #18` https://github.com/binbashar/terraform-aws-cost-billing-alarm/issues/18


